### PR TITLE
Fix shift augmentation to use proper function

### DIFF
--- a/modules/data_preparation.py
+++ b/modules/data_preparation.py
@@ -78,7 +78,7 @@ def get_features(path, noise: bool, stretch_pitch: bool, shift: bool):
 
     # data with shift
     if (shift==True):
-        shift_data = da.stretch(y)
+        shift_data = da.shift(y)
         res4 = extract_features(shift_data, sr)
         result = np.vstack((result, res4)) # stacking vertically
 


### PR DESCRIPTION
## Summary
- update the shift augmentation path in `get_features` to call the dedicated `da.shift` helper
- keep the rest of the augmentation pipeline unchanged so shifted samples are still processed the same way

## Testing
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68e67890ccb0832eaa318104914db48f