### PR TITLE
Ensure feature extraction outputs remain row-oriented

### DIFF
--- a/modules/data_preparation.py
+++ b/modules/data_preparation.py
@@ -61,26 +61,26 @@ def get_features(path, noise: bool, stretch_pitch: bool, shift: bool):
 
     # feature extraction without augmentation
     res1 = extract_features(y,sr)
-    result = np.array(res1)
+    result = np.atleast_2d(res1)
 
     # data with noise
     if (noise==True):
         noise_data = da.noise(y)
         res2 = extract_features(noise_data, sr)
-        result = np.vstack((result, res2)) # stacking vertically
+        result = np.vstack((result, np.atleast_2d(res2))) # stacking vertically
 
     # data with stretching and pitching
     if (stretch_pitch==True):
         new_data = da.stretch(y)
         data_stretch_pitch = da.pitch(new_data, sr)
         res3 = extract_features(data_stretch_pitch, sr)
-        result = np.vstack((result, res3)) # stacking vertically
+        result = np.vstack((result, np.atleast_2d(res3))) # stacking vertically
 
     # data with shift
     if (shift==True):
         shift_data = da.stretch(y)
         res4 = extract_features(shift_data, sr)
-        result = np.vstack((result, res4)) # stacking vertically
+        result = np.vstack((result, np.atleast_2d(res4))) # stacking vertically
 
     return result
 
@@ -96,8 +96,8 @@ def store_features(audio_path: pd.core.frame.DataFrame, emotion: pd.core.frame.D
         # extracting features
         features = get_features(path, noise, stretch_pitch, shift)
         # storing the results and the corresponding emotion
-        for ele in features:
-            X.append(ele)
+        for sample_features in features:
+            X.append(sample_features)
             Y.append(emotion)
 
     # Store results as DataFrame


### PR DESCRIPTION
## Summary
- ensure `get_features` returns at least a 2D array so augmentation stacking remains row-wise
- keep `store_features` iterating over full feature rows for each audio sample

## Testing
- python - <<'PY'
import csv, os
base_dir = 'data/EMOVO'
audio_paths = []
for actor_dir in sorted(os.listdir(base_dir)):
    actor_path = os.path.join(base_dir, actor_dir)
    if not os.path.isdir(actor_path):
        continue
    for fname in sorted(os.listdir(actor_path)):
        if fname.lower().endswith('.wav'):
            audio_paths.append(os.path.join(actor_path, fname))
with open('checkpoints/EMOVO_features_no_aug.csv', newline='') as f:
    reader = csv.reader(f)
    header = next(reader, None)
    rows = sum(1 for _ in reader)
print('Audio files:', len(audio_paths))
print('Feature rows (excluding header):', rows)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e678922130832ea3a95b69217e3638