### PR TITLE
Handle default optional arguments for label_manager

### DIFF
--- a/modules/data_preparation.py
+++ b/modules/data_preparation.py
@@ -162,18 +162,24 @@ def data_preparation(data: pd.core.frame.DataFrame, Y_col: int=-1,
 
 
 def label_manager(data: pd.core.frame.DataFrame, Y_col: int=-1,
-                 delate: list=[], rename: dict={}):
+                 delate: list=None, rename: dict=None):
     '''Managing labels of a DataFrame.
 
     Parameters:
     > data: data as DataFrame
     > Y_col: column index number of labels (default is -1)
-    > delate: list of labels to be removed
-    > rename: dictionary of labels to be replaced with new names
+    > delate: list of labels to be removed (default is None, treated as empty list)
+    > rename: dictionary of labels to be replaced with new names (default is None, treated as empty dict)
     '''
 
     # Select labels
     Y = data.iloc[:,Y_col]
+
+    if delate is None:
+        delate = []
+
+    if rename is None:
+        rename = {}
 
     # Delate rows with unwanted labels
     if len(delate)!=0 :


### PR DESCRIPTION
## Summary
- default `label_manager` optional parameters to `None` and initialize them to empty containers internally
- clarify the function docstring to explain the new default handling

## Testing
- python -m compileall modules/data_preparation.py

------
https://chatgpt.com/codex/tasks/task_e_68e678952c28832e87eb65f15382c1c9